### PR TITLE
PyDDQ Check.run prints console report to stdout by default

### DIFF
--- a/python/pyddq/core.py
+++ b/python/pyddq/core.py
@@ -1,4 +1,5 @@
 from reporters import ConsoleReporter
+from streams import ByteArrayOutputStream
 import jvm_conversions as jc
 
 
@@ -330,16 +331,21 @@ class Check(object):
         Runs check with all the previously specified constraints and report to
         every reporter passed as an argument
         Args:
-            reporters (List[reporters.Reporter]): List ofiterable of reporters
+            reporters (List[reporters.Reporter]): iterable of reporters
                 to produce output on the check result. If not specified,
                 reporters.ConsoleReporter is used
         Returns: None
         """
+        baos = None
         if not reporters:
-            reporters = [ConsoleReporter()]
+            baos = ByteArrayOutputStream()
+            reporters = [ConsoleReporter(baos)]
 
         jvm_reporters = jc.iterable_to_scala_list(
             self._jvm,
             [reporter.get_jvm_reporter(self._jvm) for reporter in reporters]
         )
         self.jvmCheck.run(jvm_reporters)
+
+        if baos:
+            print baos.get_output()

--- a/python/pyddq/reporters.py
+++ b/python/pyddq/reporters.py
@@ -1,5 +1,4 @@
-import sys
-from pyddq.streams import PrintStream, OutputStream, FileOutputStream
+from pyddq.streams import PrintStream, OutputStream, ByteArrayOutputStream
 from py4j.java_gateway import get_field
 
 
@@ -7,10 +6,7 @@ class Reporter(object):
     def get_jvm_reporter(self, jvm, *args, **kwargs):
         raise NotImplementedError
 
-    def __init__(self, output_stream=None):
-        if not output_stream:
-            output_stream = FileOutputStream(sys.stdout)
-
+    def __init__(self, output_stream):
         if not isinstance(output_stream, OutputStream):
             raise TypeError("output_stream should be a subclass of pyddq.streams.OutputStream")
         self.output_stream = output_stream


### PR DESCRIPTION
### Problem

Running the examples from the `README.md` would not work in iPython.
### Solution

With this PR, if the reporter is not specified in the `Check.run` call, `ConsoleReporter` is used by default. Its output is written into `ByteArrayOutputStream` and then printed.
Since `print` function is used, it will output correctly to the overwritten `sys.stdout`'s.
For example, it will work in Jupyter with its `IPython.kernel.zmq.iostream.OutStream` used as `stdout`.
