### PR TITLE
Fix broken home page link in PyDDQ setup.cfg

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -4,7 +4,7 @@ summary = Python API for Drunken Data Quality
 author = Aleksandr Sorokoumov
 author-email = aleksandr.sorokoumov@gmail.com
 license = Apache License Version 2.0
-home-page = https://github.com/FRosner/drunken-data-quality/python
+home-page = https://github.com/FRosner/drunken-data-quality#python-api-1
 description-file = README.rst
 # Add here all kinds of additional classifiers as defined under
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
https://pypi.python.org/pypi/pyddq/3.2.1

Currently, it points to https://github.com/FRosner/drunken-data-quality/python which does not exist.
With this PR it will point to Python API section of `README.md`.
