### PR TITLE
Updated to Spark 2.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ version       := "4.0.0-SNAPSHOT"
 
 name          := "drunken-data-quality"
 
-scalaVersion  := "2.10.5"
+scalaVersion  := "2.10.6"
 
-crossScalaVersions := Seq("2.10.5", "2.11.7")
+crossScalaVersions := Seq("2.10.6", "2.11.8")
 
 sparkVersion := "1.6.0"
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion  := "2.10.6"
 
 crossScalaVersions := Seq("2.10.6", "2.11.8")
 
-sparkVersion := "1.6.0"
+sparkVersion := "2.0.2"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 

--- a/build.sbt
+++ b/build.sbt
@@ -38,4 +38,4 @@ javaOptions += "-XX:MaxPermSize=512m"
 
 lazy val pythonItAssembly = taskKey[Unit]("python-it-assembly")
 
-pythonItAssembly <<= assembly map { (asm) => s"cp ${asm.getAbsolutePath()} python/drunken-data-quality.jar" ! }
+pythonItAssembly := assembly map { (asm) => s"cp ${asm.getAbsolutePath()} python/drunken-data-quality.jar" ! }

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ crossScalaVersions := Seq("2.10.6", "2.11.8")
 
 sparkVersion := "2.0.2"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 
 libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion.value % "provided"
 
@@ -34,8 +34,6 @@ fork := true
 
 javaOptions += "-Xmx2G"
 
-javaOptions += "-XX:MaxPermSize=512m"
-
 lazy val pythonItAssembly = taskKey[Unit]("python-it-assembly")
 
-pythonItAssembly := assembly map { (asm) => s"cp ${asm.getAbsolutePath()} python/drunken-data-quality.jar" ! }
+pythonItAssembly <<= assembly map { (asm) => s"cp ${asm.getAbsolutePath()} python/drunken-data-quality.jar" ! }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.13

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -2,6 +2,6 @@ resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages
 
 resolvers += "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.3")
+addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.5")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
     Setup file for pyddq.
 

--- a/python/tests/integration/test_constraints.py
+++ b/python/tests/integration/test_constraints.py
@@ -1,7 +1,6 @@
 import unittest
 
-from pyspark import SparkContext
-from pyspark.sql import SQLContext
+from pyspark.sql import SparkSession
 from pyspark.sql import types as t
 
 from pyddq.core import Check
@@ -11,15 +10,14 @@ from pyddq.streams import ByteArrayOutputStream
 
 class ConstraintTest(unittest.TestCase):
     def setUp(self):
-        self.sc = SparkContext()
-        self.sqlContext = SQLContext(self.sc)
+        self.spark = SparkSession.builder.appName("Testing").master("local[4]").getOrCreate()
         self.reporter = MarkdownReporter(ByteArrayOutputStream())
 
     def tearDown(self):
-        self.sc.stop()
+        self.spark.stop()
 
     def test_hasUniqueKey(self):
-        df = self.sqlContext.createDataFrame([(1, "a"), (1, None), (3, "c")])
+        df = self.spark.createDataFrame([(1, "a"), (1, None), (3, "c")])
         check = Check(df).hasUniqueKey("_1").hasUniqueKey("_1", "_2")
         check.run([self.reporter])
         expected_output = """
@@ -36,7 +34,7 @@ It has a total number of 2 columns and 3 rows.
         )
 
     def test_isNeverNull(self):
-        df = self.sqlContext.createDataFrame([(1, "a"), (1, None), (3, "c")])
+        df = self.spark.createDataFrame([(1, "a"), (1, None), (3, "c")])
         check = Check(df).isNeverNull("_1").isNeverNull("_2")
         check.run([self.reporter])
         expected_output = """
@@ -57,7 +55,7 @@ It has a total number of 2 columns and 3 rows.
             t.StructField("_1", t.IntegerType()),
             t.StructField("_2", t.StringType()),
         ])
-        df = self.sqlContext.createDataFrame(
+        df = self.spark.createDataFrame(
             [(1, None), (1, None), (3, None)],
             schema
         )
@@ -77,7 +75,7 @@ It has a total number of 2 columns and 3 rows.
         )
 
     def test_isConvertibleTo(self):
-        df = self.sqlContext.createDataFrame([(1, "a"), (1, None), (3, "c")])
+        df = self.spark.createDataFrame([(1, "a"), (1, None), (3, "c")])
         check = Check(df)\
                 .isConvertibleTo("_1", t.IntegerType())\
                 .isConvertibleTo("_1", t.ArrayType(t.IntegerType()))
@@ -96,7 +94,7 @@ It has a total number of 2 columns and 3 rows.
         )
 
     def test_isFormattedAsDate(self):
-        df = self.sqlContext.createDataFrame([
+        df = self.spark.createDataFrame([
             ("2000-11-23 11:50:10", ),
             ("2000-5-23 11:50:10", ),
             ("2000-02-23 11:11:11", )
@@ -116,7 +114,7 @@ It has a total number of 1 columns and 3 rows.
         )
 
     def test_isAnyOf(self):
-        df = self.sqlContext.createDataFrame([(1, "a"), (2, "b"), (3, "c")])
+        df = self.spark.createDataFrame([(1, "a"), (2, "b"), (3, "c")])
         check = Check(df).isAnyOf("_1", [1, 2]).isAnyOf("_2", ["a", "b", "c"])
         check.run([self.reporter])
         expected_output = """
@@ -133,7 +131,7 @@ It has a total number of 2 columns and 3 rows.
         )
 
     def test_isMatchingRegex(self):
-        df = self.sqlContext.createDataFrame([
+        df = self.spark.createDataFrame([
             ("Hello A", "world"),
             ("Hello B", None),
             ("Hello C", "World")
@@ -157,7 +155,7 @@ It has a total number of 2 columns and 3 rows.
         )
 
     def test_hasFunctionalDependency(self):
-        df = self.sqlContext.createDataFrame([
+        df = self.spark.createDataFrame([
             (1, 2, 1, 1),
             (9, 9, 9, 2),
             (9, 9, 9, 3)
@@ -177,7 +175,7 @@ It has a total number of 4 columns and 3 rows.
         )
 
     def test_hasForeignKey(self):
-        base = self.sqlContext.createDataFrame([
+        base = self.spark.createDataFrame([
             (1, 2, 3), (1, 2, 5), (1, 3, 3)
         ])
         ref = self.sqlContext.createDataFrame([
@@ -200,10 +198,10 @@ It has a total number of 3 columns and 3 rows.
         )
 
     def test_isJoinableWith(self):
-        base = self.sqlContext.createDataFrame([
+        base = self.spark.createDataFrame([
             (1, 2, 3), (1, 2, 5), (1, 3, 3)
         ])
-        ref = self.sqlContext.createDataFrame([
+        ref = self.spark.createDataFrame([
             (1, 2, 100), (1, 3, 100)
         ])
         columnTuple1 = ("_1", "_1")
@@ -223,7 +221,7 @@ It has a total number of 3 columns and 3 rows.
         )
 
     def test_satisfies(self):
-        df = self.sqlContext.createDataFrame([
+        df = self.spark.createDataFrame([
             (1, "a"), (2, "a"), (3, "a")
         ])
         check = Check(df).satisfies("_1 > 0").satisfies("_2 = 'a'")

--- a/src/main/scala/de/frosner/ddq/constraints/FunctionalDependencyConstraint.scala
+++ b/src/main/scala/de/frosner/ddq/constraints/FunctionalDependencyConstraint.scala
@@ -16,7 +16,7 @@ case class FunctionalDependencyConstraint(determinantSet: Seq[String],
     val maybeRelevantSelection = Try(df.select(determinantColumns ++ dependentColumns: _*))
 
     val maybeDeterminantValueCounts = maybeRelevantSelection.map(_.distinct.groupBy(determinantColumns: _*).count)
-    val maybeViolatingDeterminantValuesCount = maybeDeterminantValueCounts.map(_.filter(new Column("count") !== 1).count)
+    val maybeViolatingDeterminantValuesCount = maybeDeterminantValueCounts.map(_.filter(new Column("count") =!= 1).count)
     FunctionalDependencyConstraintResult(
       constraint = this,
       data = maybeViolatingDeterminantValuesCount.toOption.map(FunctionalDependencyConstraintResultData),

--- a/src/main/scala/de/frosner/ddq/core/Check.scala
+++ b/src/main/scala/de/frosner/ddq/core/Check.scala
@@ -189,7 +189,7 @@ object Check {
   private val defaultCacheMethod = Option(StorageLevel.MEMORY_ONLY)
 
   /**
-   * Construct a check object using the given [[org.apache.spark.sql.SQLContext]] and table name.
+   * Construct a check object using the given [[org.apache.spark.sql.SparkSession]] and table name.
    *
    * @param spark Spark Session to read the table from
    * @param table Name of the table to check
@@ -210,7 +210,7 @@ object Check {
   }
 
   /**
-    * Construct a check object using the given [[org.apache.spark.sql.SQLContext]] and table name.
+    * Construct a check object using the given [[org.apache.spark.sql.SparkSession]] and table name.
     *
     * @param spark Spark session to read the table from
     * @param database Database to switch to before attempting to read the table

--- a/src/test/scala/de/frosner/ddq/constraints/AlwaysNullConstraintTest.scala
+++ b/src/test/scala/de/frosner/ddq/constraints/AlwaysNullConstraintTest.scala
@@ -9,7 +9,7 @@ class AlwaysNullConstraintTest extends FlatSpec with Matchers with SparkContexts
 
   "An AlwaysNullConstraint" should "succeed if the column is always null" in {
     val column = "column"
-    val check = Check(TestData.makeNullableStringDf(sql, List(null, null, null))).isAlwaysNull(column)
+    val check = Check(TestData.makeNullableStringDf(spark, List(null, null, null))).isAlwaysNull(column)
     val constraint = check.constraints.head
     val result = AlwaysNullConstraintResult(
       constraint = AlwaysNullConstraint(column),
@@ -21,7 +21,7 @@ class AlwaysNullConstraintTest extends FlatSpec with Matchers with SparkContexts
 
   it should "fail if the column is not always null" in {
     val column = "column"
-    val check = Check(TestData.makeNullableStringDf(sql, List("a", null, null))).isAlwaysNull(column)
+    val check = Check(TestData.makeNullableStringDf(spark, List("a", null, null))).isAlwaysNull(column)
     val constraint = check.constraints.head
     val result = AlwaysNullConstraintResult(
       constraint = AlwaysNullConstraint(column),
@@ -33,7 +33,7 @@ class AlwaysNullConstraintTest extends FlatSpec with Matchers with SparkContexts
 
   it should "error if the column is not existing" in {
     val column = "notExisting"
-    val check = Check(TestData.makeNullableStringDf(sql, List("a", null, null))).isAlwaysNull(column)
+    val check = Check(TestData.makeNullableStringDf(spark, List("a", null, null))).isAlwaysNull(column)
     val constraint = check.constraints.head
     val result = check.run().constraintResults(constraint)
     result match {
@@ -41,10 +41,9 @@ class AlwaysNullConstraintTest extends FlatSpec with Matchers with SparkContexts
       AlwaysNullConstraint("notExisting"),
       constraintError: ConstraintError,
       None
-      ) => {
+      ) =>
         val analysisException = constraintError.throwable.asInstanceOf[AnalysisException]
-        analysisException.message shouldBe "cannot resolve 'notExisting' given input columns column"
-      }
+        analysisException.message shouldBe "cannot resolve '`notExisting`' given input columns: [column]"
     }
   }
 

--- a/src/test/scala/de/frosner/ddq/constraints/AnyOfConstraintTest.scala
+++ b/src/test/scala/de/frosner/ddq/constraints/AnyOfConstraintTest.scala
@@ -10,7 +10,7 @@ class AnyOfConstraintTest extends FlatSpec with Matchers with SparkContexts {
   "An AnyOfConstraint" should "succeed if all values are inside" in {
     val column = "column"
     val allowed = Set[Any]("a", "b", "c", "d")
-    val check = Check(TestData.makeNullableStringDf(sql, List("a", "b", "c", "c"))).isAnyOf(column, allowed)
+    val check = Check(TestData.makeNullableStringDf(spark, List("a", "b", "c", "c"))).isAnyOf(column, allowed)
     val constraint = check.constraints.head
     val result = AnyOfConstraintResult(
       constraint = AnyOfConstraint("column", allowed),
@@ -23,7 +23,7 @@ class AnyOfConstraintTest extends FlatSpec with Matchers with SparkContexts {
   it should "succeed if all values are inside or null" in {
     val column = "column"
     val allowed = Set[Any]("a", "b", "c", "d")
-    val check = Check(TestData.makeNullableStringDf(sql, List("a", "b", "c", null))).isAnyOf(column, allowed)
+    val check = Check(TestData.makeNullableStringDf(spark, List("a", "b", "c", null))).isAnyOf(column, allowed)
     val constraint = check.constraints.head
     val result = AnyOfConstraintResult(
       constraint = AnyOfConstraint("column", allowed),
@@ -36,7 +36,7 @@ class AnyOfConstraintTest extends FlatSpec with Matchers with SparkContexts {
   it should "fail if there are values not inside" in {
     val column = "column"
     val allowed = Set[Any]("a", "b", "d")
-    val check = Check(TestData.makeNullableStringDf(sql, List("a", "b", "c", "c"))).isAnyOf(column, allowed)
+    val check = Check(TestData.makeNullableStringDf(spark, List("a", "b", "c", "c"))).isAnyOf(column, allowed)
     val constraint = check.constraints.head
     val result = AnyOfConstraintResult(
       constraint = AnyOfConstraint(column, allowed),
@@ -47,20 +47,18 @@ class AnyOfConstraintTest extends FlatSpec with Matchers with SparkContexts {
   }
 
   it should "error if there are values not inside" in {
-    val column = "column"
     val allowed = Set[Any]("a", "b", "d")
-    val check = Check(TestData.makeNullableStringDf(sql, List("a", "b", "c", "c"))).isAnyOf("notExisting", allowed)
+    val check = Check(TestData.makeNullableStringDf(spark, List("a", "b", "c", "c"))).isAnyOf("notExisting", allowed)
     val constraint = check.constraints.head
     val result = check.run().constraintResults(constraint)
     result match {
       case AnyOfConstraintResult(
-      AnyOfConstraint("notExisting", actualAllowed),
+      AnyOfConstraint("notExisting", _),
       None,
       constraintError: ConstraintError
-      ) => {
+      ) =>
         val analysisException = constraintError.throwable.asInstanceOf[AnalysisException]
-        analysisException.message shouldBe "cannot resolve 'notExisting' given input columns column"
-      }
+        analysisException.message shouldBe "cannot resolve '`notExisting`' given input columns: [column]"
     }
   }
 

--- a/src/test/scala/de/frosner/ddq/constraints/ColumnColumnConstraintTest.scala
+++ b/src/test/scala/de/frosner/ddq/constraints/ColumnColumnConstraintTest.scala
@@ -9,7 +9,7 @@ class ColumnColumnConstraintTest extends FlatSpec with Matchers with SparkContex
 
   "A ColumnColumnConstraint" should "succeed if all rows satisfy the given condition" in {
     val constraintColumn = new Column("column") > 0
-    val check = Check(TestData.makeIntegerDf(sql, List(1, 2, 3))).satisfies(constraintColumn)
+    val check = Check(TestData.makeIntegerDf(spark, List(1, 2, 3))).satisfies(constraintColumn)
     val constraint = check.constraints.head
     val result = ColumnColumnConstraintResult(
       constraint = ColumnColumnConstraint(constraintColumn),
@@ -21,7 +21,7 @@ class ColumnColumnConstraintTest extends FlatSpec with Matchers with SparkContex
 
   it should "fail if there is a row that does not satisfy the given condition" in {
     val constraintColumn = new Column("column") > 1
-    val check = Check(TestData.makeIntegerDf(sql, List(1, 2, 3))).satisfies(constraintColumn)
+    val check = Check(TestData.makeIntegerDf(spark, List(1, 2, 3))).satisfies(constraintColumn)
     val constraint = check.constraints.head
     val result = ColumnColumnConstraintResult(
       constraint = ColumnColumnConstraint(constraintColumn),
@@ -33,7 +33,7 @@ class ColumnColumnConstraintTest extends FlatSpec with Matchers with SparkContex
 
   it should "error if the condition references a non-existing column" in {
     val constraintColumn = new Column("notExisting") > 1
-    val check = Check(TestData.makeIntegerDf(sql, List(1, 2, 3))).satisfies(constraintColumn)
+    val check = Check(TestData.makeIntegerDf(spark, List(1, 2, 3))).satisfies(constraintColumn)
     val constraint = check.constraints.head
     val result = check.run().constraintResults(constraint)
     result match {
@@ -43,7 +43,7 @@ class ColumnColumnConstraintTest extends FlatSpec with Matchers with SparkContex
       constraintError: ConstraintError
       ) => {
         val analysisException = constraintError.throwable.asInstanceOf[AnalysisException]
-        analysisException.message shouldBe "cannot resolve 'notExisting' given input columns column"
+        analysisException.message shouldBe "cannot resolve '`notExisting`' given input columns: [column]"
       }
     }
   }

--- a/src/test/scala/de/frosner/ddq/constraints/ConditionalColumnConstraintTest.scala
+++ b/src/test/scala/de/frosner/ddq/constraints/ConditionalColumnConstraintTest.scala
@@ -10,7 +10,7 @@ class ConditionalColumnConstraintTest extends FlatSpec with Matchers with SparkC
   "A ConditionalColumnConstraint" should "succeed if all rows where the statement is true, satisfy the given condition" in {
     val statement = new Column("column1") === 1
     val implication = new Column("column2") === 0
-    val check = Check(TestData.makeIntegersDf(sql,
+    val check = Check(TestData.makeIntegersDf(spark,
       List(1, 0),
       List(2, 0),
       List(3, 0)
@@ -27,7 +27,7 @@ class ConditionalColumnConstraintTest extends FlatSpec with Matchers with SparkC
   it should "succeed if there are no rows where the statement is true" in {
     val statement = new Column("column1") === 5
     val implication = new Column("column2") === 100
-    val check = Check(TestData.makeIntegersDf(sql,
+    val check = Check(TestData.makeIntegersDf(spark,
       List(1, 0),
       List(1, 1),
       List(3, 0)
@@ -44,7 +44,7 @@ class ConditionalColumnConstraintTest extends FlatSpec with Matchers with SparkC
   it should "fail if there are rows that do not satisfy the given condition" in {
     val statement = new Column("column1") === 1
     val implication = new Column("column2") === 0
-    val check = Check(TestData.makeIntegersDf(sql,
+    val check = Check(TestData.makeIntegersDf(spark,
       List(1, 0),
       List(1, 1),
       List(3, 0)
@@ -61,7 +61,7 @@ class ConditionalColumnConstraintTest extends FlatSpec with Matchers with SparkC
   it should "error if the condition references a non-existing column" in {
     val statement = new Column("notExisting") === 1
     val implication = new Column("column2") === 0
-    val check = Check(TestData.makeIntegersDf(sql,
+    val check = Check(TestData.makeIntegersDf(spark,
       List(1, 0),
       List(1, 1),
       List(3, 0)
@@ -75,7 +75,7 @@ class ConditionalColumnConstraintTest extends FlatSpec with Matchers with SparkC
         constraintError: ConstraintError
       ) => {
         val analysisException = constraintError.throwable.asInstanceOf[AnalysisException]
-        analysisException.message shouldBe "cannot resolve 'notExisting' given input columns column1, column2"
+        analysisException.message shouldBe "cannot resolve '`notExisting`' given input columns: [column1, column2]"
       }
     }
   }

--- a/src/test/scala/de/frosner/ddq/constraints/DateFormatConstraintTest.scala
+++ b/src/test/scala/de/frosner/ddq/constraints/DateFormatConstraintTest.scala
@@ -12,7 +12,7 @@ class DateFormatConstraintTest extends FlatSpec with Matchers with SparkContexts
   "A DateFormatConstraint" should "succeed if all elements can be converted to Date" in {
     val column = "column"
     val format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
-    val check = Check(TestData.makeNullableStringDf(sql, List("2000-11-23 11:50:10", "2000-5-23 11:50:10", "2000-02-23 11:11:11"))).
+    val check = Check(TestData.makeNullableStringDf(spark, List("2000-11-23 11:50:10", "2000-5-23 11:50:10", "2000-02-23 11:11:11"))).
       isFormattedAsDate(column, format)
     val constraint = check.constraints.head
     val result = DateFormatConstraintResult(
@@ -26,7 +26,7 @@ class DateFormatConstraintTest extends FlatSpec with Matchers with SparkContexts
   it should "succeed if all elements can be converted to Date or are null" in {
     val column = "column"
     val format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
-    val check = Check(TestData.makeNullableStringDf(sql, List("2000-11-23 11:50:10", null, "2000-02-23 11:11:11"))).
+    val check = Check(TestData.makeNullableStringDf(spark, List("2000-11-23 11:50:10", null, "2000-02-23 11:11:11"))).
       isFormattedAsDate(column, format)
     val constraint = check.constraints.head
     val result = DateFormatConstraintResult(
@@ -40,7 +40,7 @@ class DateFormatConstraintTest extends FlatSpec with Matchers with SparkContexts
   it should "fail if at least one element cannot be converted to Date" in {
     val column = "column"
     val format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
-    val check =  Check(TestData.makeNullableStringDf(sql, List("2000-11-23 11:50:10", "abc", "2000-15-23 11:11:11"))).
+    val check =  Check(TestData.makeNullableStringDf(spark, List("2000-11-23 11:50:10", "abc", "2000-15-23 11:11:11"))).
       isFormattedAsDate(column, format)
     val constraint = check.constraints.head
     val result = DateFormatConstraintResult(
@@ -54,7 +54,7 @@ class DateFormatConstraintTest extends FlatSpec with Matchers with SparkContexts
   it should "error if the condition references a non-existing column" in {
     val column = "notExisting"
     val format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
-    val check =  Check(TestData.makeNullableStringDf(sql, List("2000-11-23 11:50:10", "abc", "2000-15-23 11:11:11"))).
+    val check =  Check(TestData.makeNullableStringDf(spark, List("2000-11-23 11:50:10", "abc", "2000-15-23 11:11:11"))).
       isFormattedAsDate(column, format)
     val constraint = check.constraints.head
     val result = check.run().constraintResults(constraint)
@@ -65,7 +65,7 @@ class DateFormatConstraintTest extends FlatSpec with Matchers with SparkContexts
       constraintError: ConstraintError
       ) => {
         val analysisException = constraintError.throwable.asInstanceOf[AnalysisException]
-        analysisException.message shouldBe "cannot resolve 'notExisting' given input columns column"
+        analysisException.message shouldBe "cannot resolve '`notExisting`' given input columns: [column]"
       }
     }
   }

--- a/src/test/scala/de/frosner/ddq/constraints/ForeignKeyConstraintTest.scala
+++ b/src/test/scala/de/frosner/ddq/constraints/ForeignKeyConstraintTest.scala
@@ -11,8 +11,8 @@ class ForeignKeyConstraintTest extends FlatSpec with Matchers with MockitoSugar 
 
   "A ForeignKeyConstraint" should "succeed if the given column is a foreign key pointing to the reference table" in {
     val columns = "column" -> "column"
-    val base = TestData.makeIntegerDf(sql, List(1, 1, 1, 2, 2, 3))
-    val ref = TestData.makeIntegerDf(sql, List(1, 2, 3))
+    val base = TestData.makeIntegerDf(spark, List(1, 1, 1, 2, 2, 3))
+    val ref = TestData.makeIntegerDf(spark, List(1, 2, 3))
     val check = Check(base).hasForeignKey(ref, columns)
     val constraint = check.constraints.head
     val result = ForeignKeyConstraintResult(
@@ -26,8 +26,8 @@ class ForeignKeyConstraintTest extends FlatSpec with Matchers with MockitoSugar 
   it should "succeed if the given columns are a foreign key pointing to the reference table" in {
     val columns1 = "column1" -> "column1"
     val columns2 = "column2" -> "column2"
-    val base = TestData.makeIntegersDf(sql, List(1, 2, 3), List(1, 2, 5), List(1, 3, 3))
-    val ref = TestData.makeIntegersDf(sql, List(1, 2, 100), List(1, 3, 100))
+    val base = TestData.makeIntegersDf(spark, List(1, 2, 3), List(1, 2, 5), List(1, 3, 3))
+    val ref = TestData.makeIntegersDf(spark, List(1, 2, 100), List(1, 3, 100))
     val check = Check(base).hasForeignKey(ref, columns1, columns2)
     val constraint = check.constraints.head
     val result = ForeignKeyConstraintResult(
@@ -41,8 +41,8 @@ class ForeignKeyConstraintTest extends FlatSpec with Matchers with MockitoSugar 
   it should "succeed if the given columns are a foreign key pointing to the reference table having a different name" in {
     val columns1 = "column1" -> "column1"
     val columns2 = "column3" -> "column2"
-    val base = TestData.makeIntegersDf(sql, List(1, 2, 3), List(1, 2, 5), List(1, 3, 3))
-    val ref = TestData.makeIntegersDf(sql, List(1, 3, 100), List(1, 5, 100))
+    val base = TestData.makeIntegersDf(spark, List(1, 2, 3), List(1, 2, 5), List(1, 3, 3))
+    val ref = TestData.makeIntegersDf(spark, List(1, 3, 100), List(1, 5, 100))
     val check = Check(base).hasForeignKey(ref, columns1, columns2)
     val constraint = check.constraints.head
     val result = ForeignKeyConstraintResult(
@@ -55,8 +55,8 @@ class ForeignKeyConstraintTest extends FlatSpec with Matchers with MockitoSugar 
 
   it should "fail if the given column contains values that are not found in the reference table" in {
     val columns = "column" -> "column"
-    val base = TestData.makeIntegerDf(sql, List(1, 1, 1, 2, 2, 3))
-    val ref = TestData.makeIntegerDf(sql, List(1, 2))
+    val base = TestData.makeIntegerDf(spark, List(1, 1, 1, 2, 2, 3))
+    val ref = TestData.makeIntegerDf(spark, List(1, 2))
     val check = Check(base).hasForeignKey(ref, columns)
     val constraint = check.constraints.head
     val result = ForeignKeyConstraintResult(
@@ -70,8 +70,8 @@ class ForeignKeyConstraintTest extends FlatSpec with Matchers with MockitoSugar 
   it should "fail if the given columns contains values that are not found in the reference table" in {
     val columns1 = "column1" -> "column1"
     val columns2 = "column2" -> "column2"
-    val base = TestData.makeIntegersDf(sql, List(1, 2, 3), List(1, 2, 5), List(1, 5, 3))
-    val ref = TestData.makeIntegersDf(sql, List(1, 2, 100), List(1, 3, 100))
+    val base = TestData.makeIntegersDf(spark, List(1, 2, 3), List(1, 2, 5), List(1, 5, 3))
+    val ref = TestData.makeIntegersDf(spark, List(1, 2, 100), List(1, 3, 100))
     val check = Check(base).hasForeignKey(ref, columns1, columns2)
     val constraint = check.constraints.head
     val result = ForeignKeyConstraintResult(
@@ -85,8 +85,8 @@ class ForeignKeyConstraintTest extends FlatSpec with Matchers with MockitoSugar 
   it should "fail if the foreign key is not a primary key in the reference table" in {
     val columns1 = "column1" -> "column1"
     val columns2 = "column3" -> "column2"
-    val base = TestData.makeIntegersDf(sql, List(1, 2, 3), List(1, 2, 5), List(1, 3, 3))
-    val ref = TestData.makeIntegersDf(sql, List(1, 3, 100), List(1, 5, 100), List(1, 5, 500))
+    val base = TestData.makeIntegersDf(spark, List(1, 2, 3), List(1, 2, 5), List(1, 3, 3))
+    val ref = TestData.makeIntegersDf(spark, List(1, 3, 100), List(1, 5, 100), List(1, 5, 500))
     val check = Check(base).hasForeignKey(ref, columns1, columns2)
     val constraint = check.constraints.head
     val result = ForeignKeyConstraintResult(
@@ -100,8 +100,8 @@ class ForeignKeyConstraintTest extends FlatSpec with Matchers with MockitoSugar 
   it should "error if a column does not exist in the base table" in {
     val columns1 = "notExisting" -> "column1"
     val columns2 = "column3" -> "column2"
-    val base = TestData.makeIntegersDf(sql, List(1, 2, 3), List(1, 2, 5), List(1, 3, 3))
-    val ref = TestData.makeIntegersDf(sql, List(1, 3), List(1, 5))
+    val base = TestData.makeIntegersDf(spark, List(1, 2, 3), List(1, 2, 5), List(1, 3, 3))
+    val ref = TestData.makeIntegersDf(spark, List(1, 3), List(1, 5))
     val check = Check(base).hasForeignKey(ref, columns1, columns2)
     val constraint = check.constraints.head
     val result = check.run().constraintResults(constraint)
@@ -110,18 +110,17 @@ class ForeignKeyConstraintTest extends FlatSpec with Matchers with MockitoSugar 
         ForeignKeyConstraint(Seq(("notExisting", "column1"), ("column3", "column2")), _),
         None,
         constraintError: ConstraintError
-      ) => {
+      ) =>
         val analysisException = constraintError.throwable.asInstanceOf[AnalysisException]
-        analysisException.message shouldBe "cannot resolve 'notExisting' given input columns column1, column2, column3"
-      }
+        analysisException.message shouldBe "cannot resolve '`notExisting`' given input columns: [column1, column2, column3]"
     }
   }
 
   it should "error if a column does not exist in the ref table" in {
     val columns1 = "column1" -> "notExisting"
     val columns2 = "column3" -> "column2"
-    val base = TestData.makeIntegersDf(sql, List(1, 2, 3), List(1, 2, 5), List(1, 3, 3))
-    val ref = TestData.makeIntegersDf(sql, List(1, 3), List(1, 5), List(1, 5))
+    val base = TestData.makeIntegersDf(spark, List(1, 2, 3), List(1, 2, 5), List(1, 3, 3))
+    val ref = TestData.makeIntegersDf(spark, List(1, 3), List(1, 5), List(1, 5))
     val check = Check(base).hasForeignKey(ref, columns1, columns2)
     val constraint = check.constraints.head
     val result = check.run().constraintResults(constraint)
@@ -130,10 +129,9 @@ class ForeignKeyConstraintTest extends FlatSpec with Matchers with MockitoSugar 
       ForeignKeyConstraint(Seq(("column1", "notExisting"), ("column3", "column2")), _),
       None,
       constraintError: ConstraintError
-      ) => {
+      ) =>
         val analysisException = constraintError.throwable.asInstanceOf[AnalysisException]
-        analysisException.message shouldBe "cannot resolve 'notExisting' given input columns column1, column2"
-      }
+        analysisException.message shouldBe "cannot resolve '`notExisting`' given input columns: [column1, column2]"
     }
   }
 

--- a/src/test/scala/de/frosner/ddq/constraints/FunctionalDependencyConstraintTest.scala
+++ b/src/test/scala/de/frosner/ddq/constraints/FunctionalDependencyConstraintTest.scala
@@ -11,7 +11,7 @@ class FunctionalDependencyConstraintTest extends FlatSpec with Matchers with Spa
     "the column values in the dependent set" in {
     val determinantSet = Seq("column1", "column2")
     val dependentSet = Seq("column3")
-    val check = Check(TestData.makeIntegersDf(sql,
+    val check = Check(TestData.makeIntegersDf(spark,
       List(1, 2, 1, 1),
       List(9, 9, 9, 2),
       List(9, 9, 9, 3),
@@ -30,7 +30,7 @@ class FunctionalDependencyConstraintTest extends FlatSpec with Matchers with Spa
   it should "succeed also for dependencies where the determinant and dependent sets are not distinct" in {
     val determinantSet = Seq("column1", "column2")
     val dependentSet = Seq("column2", "column3")
-    val check = Check(TestData.makeIntegersDf(sql,
+    val check = Check(TestData.makeIntegersDf(spark,
       List(1, 2, 3, 1),
       List(9, 9, 9, 2),
       List(9, 9, 9, 3),
@@ -49,7 +49,7 @@ class FunctionalDependencyConstraintTest extends FlatSpec with Matchers with Spa
   it should "succeed if the determinant and dependent sets are equal" in {
     val determinantSet = Seq("column")
     val dependentSet = determinantSet
-    val check = Check(TestData.makeIntegerDf(sql,
+    val check = Check(TestData.makeIntegerDf(spark,
       List(1, 2, 3)
     )).hasFunctionalDependency(determinantSet, dependentSet)
     val constraint = check.constraints.head
@@ -64,7 +64,7 @@ class FunctionalDependencyConstraintTest extends FlatSpec with Matchers with Spa
   it should "fail if the column values in the determinant set don't always correspond to the column values in the dependent set" in {
     val determinantSet = Seq("column1", "column2")
     val dependentSet = Seq("column3")
-    val check = Check(TestData.makeIntegersDf(sql,
+    val check = Check(TestData.makeIntegersDf(spark,
       List(1, 2, 1, 1),
       List(9, 9, 9, 1),
       List(9, 9, 8, 1),
@@ -84,7 +84,7 @@ class FunctionalDependencyConstraintTest extends FlatSpec with Matchers with Spa
   it should "fail also for dependencies where the determinant and dependent sets are not distinct" in {
     val determinantSet = Seq("column1", "column2")
     val dependentSet = Seq("column2", "column3")
-    val check = Check(TestData.makeIntegersDf(sql,
+    val check = Check(TestData.makeIntegersDf(spark,
       List(1, 2, 1, 1),
       List(9, 9, 9, 1),
       List(9, 9, 8, 1),
@@ -103,7 +103,7 @@ class FunctionalDependencyConstraintTest extends FlatSpec with Matchers with Spa
   it should "error if a column in the determinant set does not exist" in {
     val determinantSet = Seq("notExisting", "column2")
     val dependentSet = Seq("column2", "column3")
-    val check = Check(TestData.makeIntegersDf(sql,
+    val check = Check(TestData.makeIntegersDf(spark,
       List(1, 2, 3, 1),
       List(9, 9, 9, 2),
       List(9, 9, 9, 3),
@@ -119,7 +119,7 @@ class FunctionalDependencyConstraintTest extends FlatSpec with Matchers with Spa
         constraintError: ConstraintError
       ) => {
         val analysisException = constraintError.throwable.asInstanceOf[AnalysisException]
-        analysisException.message shouldBe "cannot resolve 'notExisting' given input columns column1, column2, column3, column4"
+        analysisException.message shouldBe "cannot resolve '`notExisting`' given input columns: [column1, column2, column3, column4]"
       }
     }
   }
@@ -127,7 +127,7 @@ class FunctionalDependencyConstraintTest extends FlatSpec with Matchers with Spa
   it should "error if a column in the dependent set does not exist" in {
     val determinantSet = Seq("column1", "column2")
     val dependentSet = Seq("notExisting", "column3")
-    val check = Check(TestData.makeIntegersDf(sql,
+    val check = Check(TestData.makeIntegersDf(spark,
       List(1, 2, 3, 1),
       List(9, 9, 9, 2),
       List(9, 9, 9, 3),
@@ -143,14 +143,14 @@ class FunctionalDependencyConstraintTest extends FlatSpec with Matchers with Spa
       constraintError: ConstraintError
       ) => {
         val analysisException = constraintError.throwable.asInstanceOf[AnalysisException]
-        analysisException.message shouldBe "cannot resolve 'notExisting' given input columns column1, column2, column3, column4"
+        analysisException.message shouldBe "cannot resolve '`notExisting`' given input columns: [column1, column2, column3, column4]"
       }
     }
   }
 
   it should "require the determinant set to be non-empty" in {
     intercept[IllegalArgumentException] {
-      Check(TestData.makeIntegersDf(sql,
+      Check(TestData.makeIntegersDf(spark,
         List(1, 2, 3),
         List(4, 5, 6)
       )).hasFunctionalDependency(Seq.empty, Seq("column0"))
@@ -159,7 +159,7 @@ class FunctionalDependencyConstraintTest extends FlatSpec with Matchers with Spa
 
   it should "require the dependent set to be non-empty" in {
     intercept[IllegalArgumentException] {
-      Check(TestData.makeIntegersDf(sql,
+      Check(TestData.makeIntegersDf(spark,
         List(1, 2, 3),
         List(4, 5, 6)
       )).hasFunctionalDependency(Seq("column0"), Seq.empty)

--- a/src/test/scala/de/frosner/ddq/constraints/JoinableConstraintTest.scala
+++ b/src/test/scala/de/frosner/ddq/constraints/JoinableConstraintTest.scala
@@ -11,8 +11,8 @@ class JoinableConstraintTest extends FlatSpec with Matchers with MockitoSugar wi
 
   "A JoinableConstraint" should "succeed if a join on the given column yields at least one row" in {
     val columns = "column" -> "column"
-    val base = TestData.makeIntegerDf(sql, List(1, 1, 1, 2, 2, 3))
-    val ref = TestData.makeIntegerDf(sql, List(1, 2, 5))
+    val base = TestData.makeIntegerDf(spark, List(1, 1, 1, 2, 2, 3))
+    val ref = TestData.makeIntegerDf(spark, List(1, 2, 5))
     val check = Check(base).isJoinableWith(ref, columns)
     val constraint = check.constraints.head
     val result = JoinableConstraintResult(
@@ -29,8 +29,8 @@ class JoinableConstraintTest extends FlatSpec with Matchers with MockitoSugar wi
   it should "succeed if a join on the given columns yields at least one row" in {
     val columns1 = "column1" -> "column1"
     val columns2 = "column2" -> "column2"
-    val base = TestData.makeIntegersDf(sql, List(1, 2, 3), List(1, 2, 5), List(1, 3, 3))
-    val ref = TestData.makeIntegersDf(sql, List(1, 2, 100), List(1, 5, 100))
+    val base = TestData.makeIntegersDf(spark, List(1, 2, 3), List(1, 2, 5), List(1, 3, 3))
+    val ref = TestData.makeIntegersDf(spark, List(1, 2, 100), List(1, 5, 100))
     val check = Check(base).isJoinableWith(ref, columns1, columns2)
     val constraint = check.constraints.head
     val result = JoinableConstraintResult(
@@ -47,8 +47,8 @@ class JoinableConstraintTest extends FlatSpec with Matchers with MockitoSugar wi
   it should "succeed if a join on the given columns yields at least one row if the columns have a different name" in {
     val columns1 = "column1" -> "column1"
     val columns2 = "column3" -> "column2"
-    val base = TestData.makeIntegersDf(sql, List(1, 2, 5), List(1, 2, 5), List(1, 100, 3))
-    val ref = TestData.makeIntegersDf(sql, List(1, 3, 100), List(1, 500, 100))
+    val base = TestData.makeIntegersDf(spark, List(1, 2, 5), List(1, 2, 5), List(1, 100, 3))
+    val ref = TestData.makeIntegersDf(spark, List(1, 3, 100), List(1, 500, 100))
     val check = Check(base).isJoinableWith(ref, columns1, columns2)
     val constraint = check.constraints.head
     val result = JoinableConstraintResult(
@@ -65,8 +65,8 @@ class JoinableConstraintTest extends FlatSpec with Matchers with MockitoSugar wi
   it should "compute the matched keys in a non-commutative way" in {
     val columns = "column" -> "column"
 
-    val base = TestData.makeIntegerDf(sql, List(1, 1, 1, 1, 1, 1, 1, 1, 1, 2))
-    val ref = TestData.makeIntegerDf(sql, List(1))
+    val base = TestData.makeIntegerDf(spark, List(1, 1, 1, 1, 1, 1, 1, 1, 1, 2))
+    val ref = TestData.makeIntegerDf(spark, List(1))
 
     val check1 = Check(base).isJoinableWith(ref, columns)
     val constraint1 = check1.constraints.head
@@ -96,8 +96,8 @@ class JoinableConstraintTest extends FlatSpec with Matchers with MockitoSugar wi
   it should "fail if a join on the given columns yields no result" in {
     val columns1 = "column1" -> "column1"
     val columns2 = "column3" -> "column2"
-    val base = TestData.makeIntegersDf(sql, List(1, 2, 5), List(1, 2, 5), List(1, 100, 3))
-    val ref = TestData.makeIntegersDf(sql, List(1, 1, 100), List(1, 10, 100))
+    val base = TestData.makeIntegersDf(spark, List(1, 2, 5), List(1, 2, 5), List(1, 100, 3))
+    val ref = TestData.makeIntegersDf(spark, List(1, 1, 100), List(1, 10, 100))
     val check = Check(base).isJoinableWith(ref, columns1, columns2)
     val constraint = check.constraints.head
     val result = JoinableConstraintResult(
@@ -113,8 +113,8 @@ class JoinableConstraintTest extends FlatSpec with Matchers with MockitoSugar wi
 
   it should "fail if a join on the given columns is not possible due to mismatching types" in {
     val columns = "column" -> "column"
-    val base = TestData.makeNullableStringDf(sql, List("a", "b"))
-    val ref = TestData.makeIntegerDf(sql, List(1, 2, 3))
+    val base = TestData.makeNullableStringDf(spark, List("a", "b"))
+    val ref = TestData.makeIntegerDf(spark, List(1, 2, 3))
     val check = Check(base).isJoinableWith(ref, columns)
     val constraint = check.constraints.head
     val result = JoinableConstraintResult(
@@ -130,8 +130,8 @@ class JoinableConstraintTest extends FlatSpec with Matchers with MockitoSugar wi
 
   private def checkError(checkRef: Boolean) = {
     val columns = if (checkRef) "column" -> "notExisting" else "notExisting" -> "column"
-    val base = TestData.makeIntegerDf(sql, List(1, 1, 1, 2, 2, 3))
-    val ref = TestData.makeIntegerDf(sql, List(1, 2, 5))
+    val base = TestData.makeIntegerDf(spark, List(1, 1, 1, 2, 2, 3))
+    val ref = TestData.makeIntegerDf(spark, List(1, 2, 5))
     val check = Check(base).isJoinableWith(ref, columns)
     val constraint = check.constraints.head
     val result = check.run().constraintResults(constraint)
@@ -142,7 +142,7 @@ class JoinableConstraintTest extends FlatSpec with Matchers with MockitoSugar wi
       constraintError: ConstraintError
       ) => {
         val analysisException = constraintError.throwable.asInstanceOf[AnalysisException]
-        analysisException.message shouldBe "cannot resolve 'notExisting' given input columns column"
+        analysisException.message shouldBe "cannot resolve '`notExisting`' given input columns: [column]"
       }
     }
   }

--- a/src/test/scala/de/frosner/ddq/constraints/NeverNullConstraintTest.scala
+++ b/src/test/scala/de/frosner/ddq/constraints/NeverNullConstraintTest.scala
@@ -9,7 +9,7 @@ class NeverNullConstraintTest extends FlatSpec with Matchers with SparkContexts 
 
   "A NeverNullConstraint" should "succeed if the column contains no null values" in {
     val column = "column"
-    val check = Check(TestData.makeNullableStringDf(sql, List("a", "b", "c"))).isNeverNull(column)
+    val check = Check(TestData.makeNullableStringDf(spark, List("a", "b", "c"))).isNeverNull(column)
     val constraint = check.constraints.head
     val result = NeverNullConstraintResult(
       constraint = NeverNullConstraint(column),
@@ -21,7 +21,7 @@ class NeverNullConstraintTest extends FlatSpec with Matchers with SparkContexts 
 
   it should "fail if the column contains null values" in {
     val column = "column"
-    val check = Check(TestData.makeNullableStringDf(sql, List("a", "b", null))).isNeverNull(column)
+    val check = Check(TestData.makeNullableStringDf(spark, List("a", "b", null))).isNeverNull(column)
     val constraint = check.constraints.head
     val result = NeverNullConstraintResult(
       constraint = NeverNullConstraint(column),
@@ -33,7 +33,7 @@ class NeverNullConstraintTest extends FlatSpec with Matchers with SparkContexts 
 
   it should "error if the column is not existing" in {
     val column = "notExisting"
-    val check = Check(TestData.makeNullableStringDf(sql, List("a", null, null))).isNeverNull(column)
+    val check = Check(TestData.makeNullableStringDf(spark, List("a", null, null))).isNeverNull(column)
     val constraint = check.constraints.head
     val result = check.run().constraintResults(constraint)
     result match {
@@ -43,7 +43,7 @@ class NeverNullConstraintTest extends FlatSpec with Matchers with SparkContexts 
       constraintError: ConstraintError
       ) => {
         val analysisException = constraintError.throwable.asInstanceOf[AnalysisException]
-        analysisException.message shouldBe "cannot resolve 'notExisting' given input columns column"
+        analysisException.message shouldBe "cannot resolve '`notExisting`' given input columns: [column]"
       }
     }
   }

--- a/src/test/scala/de/frosner/ddq/constraints/NumberOfRowsConstraintTest.scala
+++ b/src/test/scala/de/frosner/ddq/constraints/NumberOfRowsConstraintTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.{FlatSpec, Matchers}
 class NumberOfRowsConstraintTest extends FlatSpec with Matchers with SparkContexts {
 
   "A NumberOfRowsConstraint" should "succeed if the actual number of rows is equal to the expected" in {
-    val check = Check(TestData.makeIntegerDf(sql, List(1, 2, 3))).hasNumRows(_ === 3)
+    val check = Check(TestData.makeIntegerDf(spark, List(1, 2, 3))).hasNumRows(_ === 3)
     val constraint = check.constraints.head
     val result = NumberOfRowsConstraintResult(
       constraint = NumberOfRowsConstraint(new Column(NumberOfRowsConstraint.countKey) === 3),
@@ -19,7 +19,7 @@ class NumberOfRowsConstraintTest extends FlatSpec with Matchers with SparkContex
   }
 
   it should "fail if the number of rows is not in the expected range" in {
-    val check = Check(TestData.makeIntegerDf(sql, List(1, 2, 3))).hasNumRows(
+    val check = Check(TestData.makeIntegerDf(spark, List(1, 2, 3))).hasNumRows(
       numRows => numRows < 3 || numRows > 3
     )
     val constraint = check.constraints.head

--- a/src/test/scala/de/frosner/ddq/constraints/RegexConstraintTest.scala
+++ b/src/test/scala/de/frosner/ddq/constraints/RegexConstraintTest.scala
@@ -10,7 +10,7 @@ class RegexConstraintTest extends FlatSpec with Matchers with SparkContexts {
   "A RegexConstraint" should "succeed if all values satisfy the regex" in {
     val column = "column"
     val regex = "^Hello"
-    val check = Check(TestData.makeNullableStringDf(sql, List("Hello A", "Hello B", "Hello C"))).isMatchingRegex(column, regex)
+    val check = Check(TestData.makeNullableStringDf(spark, List("Hello A", "Hello B", "Hello C"))).isMatchingRegex(column, regex)
     val constraint = check.constraints.head
     val result = RegexConstraintResult(
       constraint = RegexConstraint(column, regex),
@@ -23,7 +23,7 @@ class RegexConstraintTest extends FlatSpec with Matchers with SparkContexts {
   it should "succeed if all values satisfy the regex or are null" in {
     val column = "column"
     val regex = "^Hello"
-    val check = Check(TestData.makeNullableStringDf(sql, List("Hello A", "Hello B", null))).isMatchingRegex(column, regex)
+    val check = Check(TestData.makeNullableStringDf(spark, List("Hello A", "Hello B", null))).isMatchingRegex(column, regex)
     val constraint = check.constraints.head
     val result = RegexConstraintResult(
       constraint = RegexConstraint(column, regex),
@@ -36,7 +36,7 @@ class RegexConstraintTest extends FlatSpec with Matchers with SparkContexts {
   it should "fail if there is a row not satisfying the regex" in {
     val column = "column"
     val regex = "^Hello A$"
-    val check = Check(TestData.makeNullableStringDf(sql, List("Hello A", "Hello A", "Hello B"))).isMatchingRegex(column, regex)
+    val check = Check(TestData.makeNullableStringDf(spark, List("Hello A", "Hello A", "Hello B"))).isMatchingRegex(column, regex)
     val constraint = check.constraints.head
     val result = RegexConstraintResult(
       constraint = RegexConstraint(column, regex),
@@ -49,7 +49,7 @@ class RegexConstraintTest extends FlatSpec with Matchers with SparkContexts {
   it should "error if the column does not exist" in {
     val column = "notExisting"
     val regex = "^Hello"
-    val check = Check(TestData.makeNullableStringDf(sql, List("Hello A", "Hello B", "Hello C"))).isMatchingRegex(column, regex)
+    val check = Check(TestData.makeNullableStringDf(spark, List("Hello A", "Hello B", "Hello C"))).isMatchingRegex(column, regex)
     val constraint = check.constraints.head
     val result = check.run().constraintResults(constraint)
     result match {
@@ -59,7 +59,7 @@ class RegexConstraintTest extends FlatSpec with Matchers with SparkContexts {
       constraintError: ConstraintError
       ) => {
         val analysisException = constraintError.throwable.asInstanceOf[AnalysisException]
-        analysisException.message shouldBe "cannot resolve 'notExisting' given input columns column"
+        analysisException.message shouldBe "cannot resolve '`notExisting`' given input columns: [column]"
       }
     }
   }

--- a/src/test/scala/de/frosner/ddq/constraints/StringColumnConstraintTest.scala
+++ b/src/test/scala/de/frosner/ddq/constraints/StringColumnConstraintTest.scala
@@ -9,7 +9,7 @@ class StringColumnConstraintTest extends FlatSpec with Matchers with SparkContex
 
   "A StringColumnConstraint" should "succeed if all rows satisfy the given condition" in {
     val constraintString = "column > 0"
-    val check = Check(TestData.makeIntegerDf(sql, List(1, 2, 3))).satisfies(constraintString)
+    val check = Check(TestData.makeIntegerDf(spark, List(1, 2, 3))).satisfies(constraintString)
     val constraint = check.constraints.head
     val result = StringColumnConstraintResult(
       constraint = StringColumnConstraint(constraintString),
@@ -21,7 +21,7 @@ class StringColumnConstraintTest extends FlatSpec with Matchers with SparkContex
 
   it should "fail if there are rows that do not satisfy the given condition" in {
     val constraintString = "column > 1"
-    val check = Check(TestData.makeIntegerDf(sql, List(1, 2, 3))).satisfies(constraintString)
+    val check = Check(TestData.makeIntegerDf(spark, List(1, 2, 3))).satisfies(constraintString)
     val constraint = check.constraints.head
     val result = StringColumnConstraintResult(
       constraint = StringColumnConstraint(constraintString),
@@ -33,7 +33,7 @@ class StringColumnConstraintTest extends FlatSpec with Matchers with SparkContex
 
   it should "error if the column does not exist" in {
     val constraintString = "notExisting > 0"
-    val check = Check(TestData.makeIntegerDf(sql, List(1, 2, 3))).satisfies(constraintString)
+    val check = Check(TestData.makeIntegerDf(spark, List(1, 2, 3))).satisfies(constraintString)
     val constraint = check.constraints.head
     val result = check.run().constraintResults(constraint)
     result match {
@@ -43,7 +43,7 @@ class StringColumnConstraintTest extends FlatSpec with Matchers with SparkContex
       constraintError: ConstraintError
       ) => {
         val analysisException = constraintError.throwable.asInstanceOf[AnalysisException]
-        analysisException.message shouldBe "cannot resolve 'notExisting' given input columns column"
+        analysisException.message shouldBe "cannot resolve '`notExisting`' given input columns: [column]"
       }
     }
   }

--- a/src/test/scala/de/frosner/ddq/constraints/TypeConversionConstraintTest.scala
+++ b/src/test/scala/de/frosner/ddq/constraints/TypeConversionConstraintTest.scala
@@ -11,7 +11,7 @@ class TypeConversionConstraintTest extends FlatSpec with Matchers with SparkCont
   "A TypeConversionConstraint" should "succeed if all elements can be converted" in {
     val column = "column"
     val targetType = IntegerType
-    val check = Check(TestData.makeNullableStringDf(sql, List("1", "2", "3"))).isConvertibleTo(column, targetType)
+    val check = Check(TestData.makeNullableStringDf(spark, List("1", "2", "3"))).isConvertibleTo(column, targetType)
     val constraint = check.constraints.head
     val result = TypeConversionConstraintResult(
       constraint = TypeConversionConstraint(column, targetType),
@@ -27,7 +27,7 @@ class TypeConversionConstraintTest extends FlatSpec with Matchers with SparkCont
   it should "succeed if all elements can be converted or are null" in {
     val column = "column"
     val targetType = DoubleType
-    val check = Check(TestData.makeNullableStringDf(sql, List("1.0", "2.0", null))).isConvertibleTo(column, targetType)
+    val check = Check(TestData.makeNullableStringDf(spark, List("1.0", "2.0", null))).isConvertibleTo(column, targetType)
     val constraint = check.constraints.head
     val result = TypeConversionConstraintResult(
       constraint = TypeConversionConstraint(column, targetType),
@@ -43,7 +43,7 @@ class TypeConversionConstraintTest extends FlatSpec with Matchers with SparkCont
   it should "fail if at least one element cannot be converted" in {
     val column = "column"
     val targetType = LongType
-    val check = Check(TestData.makeNullableStringDf(sql, List("1", "2", "hallo", "test"))).isConvertibleTo(column, targetType)
+    val check = Check(TestData.makeNullableStringDf(spark, List("1", "2", "hallo", "test"))).isConvertibleTo(column, targetType)
     val constraint = check.constraints.head
     val result = TypeConversionConstraintResult(
       constraint = TypeConversionConstraint(column, targetType),
@@ -59,7 +59,7 @@ class TypeConversionConstraintTest extends FlatSpec with Matchers with SparkCont
   it should "error the column does not exist" in {
     val column = "notExisting"
     val targetType = IntegerType
-    val check = Check(TestData.makeNullableStringDf(sql, List("1", "2", "3"))).isConvertibleTo(column, targetType)
+    val check = Check(TestData.makeNullableStringDf(spark, List("1", "2", "3"))).isConvertibleTo(column, targetType)
     val constraint = check.constraints.head
     val result = check.run().constraintResults(constraint)
     result match {
@@ -69,7 +69,7 @@ class TypeConversionConstraintTest extends FlatSpec with Matchers with SparkCont
         constraintError: ConstraintError
       ) => {
         val analysisException = constraintError.throwable.asInstanceOf[AnalysisException]
-        analysisException.message shouldBe "cannot resolve 'notExisting' given input columns column"
+        analysisException.message shouldBe "cannot resolve '`notExisting`' given input columns: [column]"
       }
     }
   }

--- a/src/test/scala/de/frosner/ddq/constraints/UniqueKeyConstraintTest.scala
+++ b/src/test/scala/de/frosner/ddq/constraints/UniqueKeyConstraintTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.{FlatSpec, Matchers}
 class UniqueKeyConstraintTest extends FlatSpec with Matchers with SparkContexts {
 
   "A UniqueKeyConstraint" should "succeed if a given column defines a key" in {
-    val df = TestData.makeIntegersDf(sql,
+    val df = TestData.makeIntegersDf(spark,
       List(1,2),
       List(2,3),
       List(3,3)
@@ -26,7 +26,7 @@ class UniqueKeyConstraintTest extends FlatSpec with Matchers with SparkContexts 
   }
 
   it should "succeed if the given columns define a key" in {
-    val df = TestData.makeIntegersDf(sql,
+    val df = TestData.makeIntegersDf(spark,
       List(1,2,3),
       List(2,3,3),
       List(3,2,3)
@@ -45,7 +45,7 @@ class UniqueKeyConstraintTest extends FlatSpec with Matchers with SparkContexts 
   }
 
   it should "fail if there are duplicate rows using the given column as a key" in {
-    val df = TestData.makeIntegersDf(sql,
+    val df = TestData.makeIntegersDf(spark,
       List(1,2),
       List(2,3),
       List(2,3)
@@ -63,7 +63,7 @@ class UniqueKeyConstraintTest extends FlatSpec with Matchers with SparkContexts 
   }
 
   it should "fail if there are duplicate rows using the given columns as a key" in {
-    val df = TestData.makeIntegersDf(sql,
+    val df = TestData.makeIntegersDf(spark,
       List(1,2,3),
       List(2,3,3),
       List(1,2,3)
@@ -83,7 +83,7 @@ class UniqueKeyConstraintTest extends FlatSpec with Matchers with SparkContexts 
   }
 
   it should "error if the given column does not exist" in {
-    val df = TestData.makeIntegersDf(sql,
+    val df = TestData.makeIntegersDf(spark,
       List(1,2),
       List(2,3),
       List(3,3)
@@ -99,7 +99,7 @@ class UniqueKeyConstraintTest extends FlatSpec with Matchers with SparkContexts 
       constraintError: ConstraintError
       ) => {
         val analysisException = constraintError.throwable.asInstanceOf[AnalysisException]
-        analysisException.message shouldBe "cannot resolve 'notExisting' given input columns column1, column2"
+        analysisException.message shouldBe "cannot resolve '`notExisting`' given input columns: [column1, column2]"
       }
     }
   }

--- a/src/test/scala/de/frosner/ddq/testutils/SparkContexts.scala
+++ b/src/test/scala/de/frosner/ddq/testutils/SparkContexts.scala
@@ -1,15 +1,24 @@
 package de.frosner.ddq.testutils
 
-import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.hive.test.TestHive
+import org.apache.spark.sql.SparkSession
 
 trait SparkContexts {
 
-  protected val hive = TestHive
-  hive.setConf("spark.sql.shuffle.partitions", "5")
-  protected val sc = hive.sparkContext
-  protected val sql = new SQLContext(sc)
-  sql.setConf("spark.sql.shuffle.partitions", "5")
-  sys.addShutdownHook(hive.reset())
+  protected val spark: SparkSession =
+    SparkSession.builder
+      .master("local[4]")
+      .config("spark.sql.shuffle.partitions", "5")
+      .appName("Testing")
+      .getOrCreate()
+
+
+
+  def resetSpark() = {
+
+  }
+
+  sys.addShutdownHook(resetSpark())
 
 }
+
+

--- a/src/test/scala/de/frosner/ddq/testutils/SparkContexts.scala
+++ b/src/test/scala/de/frosner/ddq/testutils/SparkContexts.scala
@@ -1,5 +1,7 @@
 package de.frosner.ddq.testutils
 
+import java.io.File
+
 import org.apache.spark.sql.SparkSession
 
 trait SparkContexts {
@@ -12,12 +14,13 @@ trait SparkContexts {
       .getOrCreate()
 
 
+  sys.addShutdownHook(resetSpark())
+
+
 
   def resetSpark() = {
-
+    new File("spark-warehouse").delete()
   }
-
-  sys.addShutdownHook(resetSpark())
 
 }
 

--- a/src/test/scala/de/frosner/ddq/testutils/TestData.scala
+++ b/src/test/scala/de/frosner/ddq/testutils/TestData.scala
@@ -1,25 +1,25 @@
 package de.frosner.ddq.testutils
 
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 
 object TestData {
 
-  def makeIntegerDf(sql: SQLContext, numbers: Seq[Int]): DataFrame =
-    sql.createDataFrame(
-      sql.sparkContext.makeRDD(numbers.map(Row(_))),
-      StructType(List(StructField("column", IntegerType, false)))
+  def makeIntegerDf(spark: SparkSession, numbers: Seq[Int]): DataFrame =
+    spark.createDataFrame(
+      spark.sparkContext.makeRDD(numbers.map(Row(_))),
+      StructType(List(StructField("column", IntegerType, nullable = false)))
     )
 
-  def makeNullableStringDf(sql: SQLContext, strings: Seq[String]): DataFrame =
-    sql.createDataFrame(sql.sparkContext.makeRDD(strings.map(Row(_))), StructType(List(StructField("column", StringType, true))))
+  def makeNullableStringDf(spark: SparkSession, strings: Seq[String]): DataFrame =
+    spark.createDataFrame(spark.sparkContext.makeRDD(strings.map(Row(_))), StructType(List(StructField("column", StringType, nullable = true))))
 
-  def makeIntegersDf(sql: SQLContext, row1: Seq[Int], rowN: Seq[Int]*): DataFrame = {
+  def makeIntegersDf(spark: SparkSession, row1: Seq[Int], rowN: Seq[Int]*): DataFrame = {
     val rows = row1 :: rowN.toList
     val numCols = row1.size
-    val rdd = sql.sparkContext.makeRDD(rows.map(Row(_:_*)))
-    val schema = StructType((1 to numCols).map(idx => StructField("column" + idx, IntegerType, false)))
-    sql.createDataFrame(rdd, schema)
+    val rdd = spark.sparkContext.makeRDD(rows.map(Row(_:_*)))
+    val schema = StructType((1 to numCols).map(idx => StructField("column" + idx, IntegerType, nullable = false)))
+    spark.createDataFrame(rdd, schema)
   }
 
 }


### PR DESCRIPTION
I've forked your project to upgrade the Spark version to 2.x and use SparkSessions instead of SQLContext. I got everything right except the python package, normal tests are running fine but the integration tests are failing on a class not found exception. I can't get my head around it.