### PR TITLE
pyddq support for hasNumRowsEqualTo, hasNumRowsGreaterThan, hasNumRowsLessThan

### DIFF
--- a/python/pyddq/core.py
+++ b/python/pyddq/core.py
@@ -110,6 +110,63 @@ class Check(object):
             jvmCheck
         )
 
+    def hasNumRowsEqualTo(self, expected):
+        """
+        Checks whether the table has exactly the given number of rows.
+        Args:
+            expected (int): expected number of rows
+        Returns:
+            core.Check object including this constraint
+        """
+        jvmCheck = self.jvmCheck.addConstraint(
+            self._jvm.de.frosner.ddq.constraints.NumberOfRowsConstraint.equalTo(expected)
+        )
+        return Check(
+            self.dataFrame,
+            self.name,
+            self.cacheMethod,
+            self.id,
+            jvmCheck
+        )
+
+    def hasNumRowsGreaterThan(self, expected):
+        """
+        Checks whether the table has the number of rows greater than the given number
+        Args:
+            expected (int): expected number of rows
+        Returns:
+            core.Check object including this constraint
+        """
+        jvmCheck = self.jvmCheck.addConstraint(
+            self._jvm.de.frosner.ddq.constraints.NumberOfRowsConstraint.greaterThan(expected)
+        )
+        return Check(
+            self.dataFrame,
+            self.name,
+            self.cacheMethod,
+            self.id,
+            jvmCheck
+        )
+
+    def hasNumRowsLessThan(self, expected):
+        """
+        Checks whether the table has the number of rows less than the given number
+        Args:
+            expected (int): expected number of rows
+        Returns:
+            core.Check object including this constraint
+        """
+        jvmCheck = self.jvmCheck.addConstraint(
+            self._jvm.de.frosner.ddq.constraints.NumberOfRowsConstraint.lessThan(expected)
+        )
+        return Check(
+            self.dataFrame,
+            self.name,
+            self.cacheMethod,
+            self.id,
+            jvmCheck
+        )
+
     def isNeverNull(self, columnName):
         """
         Checks whether the column with the given name contains no null values.

--- a/python/tests/integration/test_constraints.py
+++ b/python/tests/integration/test_constraints.py
@@ -131,6 +131,8 @@ It has a total number of 2 columns and 3 rows.
                 .isConvertibleTo("_1", t.IntegerType())\
                 .isConvertibleTo("_1", t.ArrayType(t.IntegerType()))
         check.run([self.reporter])
+
+        # instance ids are in the output
         expected_output = """
 **Checking [_1: bigint, _2: string]**
 
@@ -138,12 +140,14 @@ It has a total number of 2 columns and 3 rows.
 
 - *SUCCESS*: Column _1 can be converted from LongType to IntegerType.
 - *ERROR*: Checking whether column _1 can be converted to ArrayType(IntegerType,true) failed: org.apache.spark.sql.AnalysisException: cannot resolve '`_1`' due to data type mismatch: cannot cast LongType to ArrayType(IntegerType,true);;
-'Project [_1#477L, cast(_1#477L as array<int>) AS _1_casted#516]\n+- LogicalRDD [_1#477L, _2#478]
+'Project [
++- LogicalRDD [
 """.strip()
-        self.assertEqual(
-            self.reporter.output_stream.get_output(),
-            expected_output
-        )
+        for actual, expected in zip(
+                self.reporter.output_stream.get_output().split("\n"),
+                expected_output.split("\n")
+        ):
+            self.assertTrue(actual.startswith(expected))
 
     def test_isFormattedAsDate(self):
         df = self.spark.createDataFrame([

--- a/python/tests/integration/test_constraints.py
+++ b/python/tests/integration/test_constraints.py
@@ -33,6 +33,57 @@ It has a total number of 2 columns and 3 rows.
             expected_output
         )
 
+    def test_hasNumRowsEqualTo(self):
+        df = self.spark.createDataFrame([(1, "a"), (1, None), (3, "c")])
+        check = Check(df).hasNumRowsEqualTo(3).hasNumRowsEqualTo(10)
+        check.run([self.reporter])
+        expected_output = """
+**Checking [_1: bigint, _2: string]**
+
+It has a total number of 2 columns and 3 rows.
+
+- *SUCCESS*: The number of rows satisfies (count = 3).
+- *FAILURE*: The actual number of rows 3 does not satisfy (count = 10).
+""".strip()
+        self.assertEqual(
+            self.reporter.output_stream.get_output(),
+            expected_output
+        )
+
+    def test_hasNumRowsGreaterThan(self):
+        df = self.spark.createDataFrame([(1, "a"), (1, None), (3, "c")])
+        check = Check(df).hasNumRowsGreaterThan(2).hasNumRowsGreaterThan(10)
+        check.run([self.reporter])
+        expected_output = """
+**Checking [_1: bigint, _2: string]**
+
+It has a total number of 2 columns and 3 rows.
+
+- *SUCCESS*: The number of rows satisfies (count > 2).
+- *FAILURE*: The actual number of rows 3 does not satisfy (count > 10).
+""".strip()
+        self.assertEqual(
+            self.reporter.output_stream.get_output(),
+            expected_output
+        )
+
+    def test_hasNumRowsLessThan(self):
+        df = self.spark.createDataFrame([(1, "a"), (1, None), (3, "c")])
+        check = Check(df).hasNumRowsLessThan(2).hasNumRowsLessThan(10)
+        check.run([self.reporter])
+        expected_output = """
+**Checking [_1: bigint, _2: string]**
+
+It has a total number of 2 columns and 3 rows.
+
+- *FAILURE*: The actual number of rows 3 does not satisfy (count < 2).
+- *SUCCESS*: The number of rows satisfies (count < 10).
+""".strip()
+        self.assertEqual(
+            self.reporter.output_stream.get_output(),
+            expected_output
+        )
+
     def test_isNeverNull(self):
         df = self.spark.createDataFrame([(1, "a"), (1, None), (3, "c")])
         check = Check(df).isNeverNull("_1").isNeverNull("_2")

--- a/python/tests/unit/test_constraints.py
+++ b/python/tests/unit/test_constraints.py
@@ -25,6 +25,24 @@ class ConstraintTest(unittest.TestCase):
             self.COLUMN_NAME, jvm_column_names
         )
 
+    def test_hasNumRowsEqualTo(self):
+        num_rows = 10
+        self.check.hasNumRowsEqualTo(num_rows)
+        self.check._jvm.de.frosner.ddq.constraints.NumberOfRowsConstraint.\
+            equalTo.assert_called_with(num_rows)
+
+    def test_hasNumRowsGreaterThan(self):
+        num_rows = 10
+        self.check.hasNumRowsGreaterThan(num_rows)
+        self.check._jvm.de.frosner.ddq.constraints.NumberOfRowsConstraint.\
+            greaterThan.assert_called_with(num_rows)
+
+    def test_hasNumRowsLessThan(self):
+        num_rows = 10
+        self.check.hasNumRowsLessThan(num_rows)
+        self.check._jvm.de.frosner.ddq.constraints.NumberOfRowsConstraint.\
+            lessThan.assert_called_with(num_rows)
+
     def test_isNeverNull(self):
         self.check.isNeverNull(self.COLUMN_NAME)
         self.jvmCheck.isNeverNull.assert_called_with(self.COLUMN_NAME)

--- a/src/main/scala/de/frosner/ddq/constraints/NumberOfRowsConstraint.scala
+++ b/src/main/scala/de/frosner/ddq/constraints/NumberOfRowsConstraint.scala
@@ -26,6 +26,18 @@ object NumberOfRowsConstraint {
     new NumberOfRowsConstraint(expected(new Column(countKey)))
   }
 
+  def greaterThan(expected: Int): NumberOfRowsConstraint = {
+    NumberOfRowsConstraint(_ > expected)
+  }
+
+  def lessThan(expected: Int): NumberOfRowsConstraint = {
+    NumberOfRowsConstraint(_ < expected)
+  }
+
+  def equalTo(expected: Int): NumberOfRowsConstraint = {
+    NumberOfRowsConstraint(_ === expected)
+  }
+
 }
 
 case class NumberOfRowsConstraintResult(constraint: NumberOfRowsConstraint,

--- a/src/main/scala/de/frosner/ddq/core/Check.scala
+++ b/src/main/scala/de/frosner/ddq/core/Check.scala
@@ -96,7 +96,7 @@ case class Check(dataFrame: DataFrame,
    * @param expected Expected number of rows.
    * @return [[core.Check]] object including this constraint
    */
-  def hasNumRows(expected: Column => Column): Check = addConstraint(Check.hasNumRowsEqualTo(expected))
+  def hasNumRows(expected: Column => Column): Check = addConstraint(Check.hasNumRows(expected))
 
   /**
     * Check whether the column with the given name can be converted to the given type.
@@ -270,7 +270,7 @@ object Check {
    * @param expected Expected number of rows.
    * @return [[constraints.Constraint]] object
    */
-  def hasNumRowsEqualTo(expected: Column => Column): Constraint = NumberOfRowsConstraint(expected)
+  def hasNumRows(expected: Column => Column): Constraint = NumberOfRowsConstraint(expected)
 
   /**
    * Check whether the given constraint is satisfied. The constraint has to comply with Spark SQL syntax. So you

--- a/src/test/scala/de/frosner/ddq/constraints/NumberOfRowsConstraintTest.scala
+++ b/src/test/scala/de/frosner/ddq/constraints/NumberOfRowsConstraintTest.scala
@@ -62,4 +62,22 @@ class NumberOfRowsConstraintTest extends FlatSpec with Matchers with SparkContex
     }
   }
 
+  "NumberOfRowsConstraint.greaterThan" should "create a correct NumberOfRowsConstraint" in {
+    val expected = 10
+    val constraint = NumberOfRowsConstraint.greaterThan(expected)
+    constraint shouldBe NumberOfRowsConstraint(new Column("count") > expected)
+  }
+
+  "NumberOfRowsConstraint.lessThan" should "create a correct NumberOfRowsConstraint" in {
+    val expected = 10
+    val constraint = NumberOfRowsConstraint.lessThan(expected)
+    constraint shouldBe NumberOfRowsConstraint(new Column("count") < expected)
+  }
+
+  "NumberOfRowsConstraint.equalTo" should "create a correct NumberOfRowsConstraint" in {
+    val expected = 10
+    val constraint = NumberOfRowsConstraint.equalTo(expected)
+    constraint shouldBe NumberOfRowsConstraint(new Column("count") === expected)
+  }
+
 }


### PR DESCRIPTION
Solves #133 by adding 3 distinct methods since I did not find how to conveniently pass Python lambdas to the Scala code.