### PR TITLE
pyscaffold 2.x breaks in python 3.10+

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -52,7 +52,7 @@ class IntegrationTestCommand(Command):
 def setup_package():
     needs_sphinx = {'build_sphinx', 'upload_docs'}.intersection(sys.argv)
     sphinx = ['sphinx'] if needs_sphinx else []
-    setup(setup_requires=['six', 'pyscaffold>=2.5a0,<2.6a0'] + sphinx,
+    setup(setup_requires=['six', 'pyscaffold>=4.5'] + sphinx,
           use_pyscaffold=True,
           cmdclass={
               "integration_test": IntegrationTestCommand


### PR DESCRIPTION
pyscaffold 2.x breaks in python 3.10+ with the message: error: invalid command 'bdist_wininst'